### PR TITLE
ESP8266 support and updates to SpaNetInterface

### DIFF
--- a/lib/SpaNetInterface/SpaNetInterface.cpp
+++ b/lib/SpaNetInterface/SpaNetInterface.cpp
@@ -1,13 +1,31 @@
 #include "SpaNetInterface.h"
 
+#define BAUD_RATE 38400
+
+#if defined(ESP8266)
+    #define RX_PIN 13 //goes to rx on spanet pin5
+    #define TX_PIN 15 //goes to tx on spanet pin6
+    HardwareSerial spaSerial = Serial;
+#elif defined(ESP32)
+    #define RX_PIN 16 //goes to rx on spanet pin5
+    #define TX_PIN 17 //goes to tx on spanet pin6
+    HardwareSerial spaSerial = Serial2;
+#endif
+
 SpaNetInterface::SpaNetInterface(Stream &p) : port(p) {
 }
 
-SpaNetInterface::SpaNetInterface() : port(Serial2) {
-    Serial2.setRxBufferSize(1024);  //required for unit testing
-    Serial2.setTxBufferSize(1024);  //required for unit testing
-    Serial2.begin(38400, SERIAL_8N1, 16, 17);
-    Serial2.setTimeout(250);
+SpaNetInterface::SpaNetInterface() : port(spaSerial) {
+    #if defined(ESP8266)
+        spaSerial.setRxBufferSize(1024);  //required for unit testing
+        spaSerial.begin(BAUD_RATE);
+        spaSerial.pins(TX_PIN, RX_PIN);
+    #elif defined(ESP32)
+        spaSerial.setRxBufferSize(1024);  //required for unit testing
+        spaSerial.setTxBufferSize(1024);  //required for unit testing
+        spaSerial.begin(BAUD_RATE, SERIAL_8N1, RX_PIN, TX_PIN);
+    #endif
+    spaSerial.setTimeout(250);
 }
 
 SpaNetInterface::~SpaNetInterface() {}

--- a/lib/SpaNetInterface/SpaNetInterface.cpp
+++ b/lib/SpaNetInterface/SpaNetInterface.cpp
@@ -179,17 +179,37 @@ bool SpaNetInterface::readStatus() {
     validStatusResponse = false;
     String statusResponseTmp = "";
 
-    while (field < 289)
+    while (field < statusResponseRawMax)
     {
         statusResponseRaw[field] = port.readStringUntil(',');
         debugV("(%i,%s)",field,statusResponseRaw[field]);
 
         statusResponseTmp = statusResponseTmp + statusResponseRaw[field]+",";
 
+        if (statusResponseRaw[field].isEmpty() && field > statusResponseRawMin) {
+            break;
+        }
         if (statusResponseRaw[field].isEmpty()) { // If we get a empty field then we've had a bad read.
             debugE("Throwing exception - null string");
             return false;
         }
+        if (field == 0 && !statusResponseRaw[field].startsWith("RF:")) { // If the first field is not "RF:" stop we don't have the start of the register
+            debugE("Throwing exception - field: %i, value: %s", field, statusResponseRaw[field]);
+            return false;
+        }
+
+        if (statusResponseRaw[field] == "R2") R2 = field;
+        if (statusResponseRaw[field] == "R3") R3 = field;
+        if (statusResponseRaw[field] == "R4") R4 = field;
+        if (statusResponseRaw[field] == "R5") R5 = field;
+        if (statusResponseRaw[field] == "R6") R6 = field;
+        if (statusResponseRaw[field] == "R7") R7 = field;
+        if (statusResponseRaw[field] == "R9") R9 = field;
+        if (statusResponseRaw[field] == "RA") RA = field;
+        if (statusResponseRaw[field] == "RB") RB = field;
+        if (statusResponseRaw[field] == "RC") RC = field;
+        if (statusResponseRaw[field] == "RE") RE = field;
+        if (statusResponseRaw[field] == "RG") RG = field;
 
         field++;
     }
@@ -199,8 +219,8 @@ bool SpaNetInterface::readStatus() {
 
     statusResponse.update_Value(statusResponseTmp);
 
-    if (field != 289) {
-        debugE("Throwing exception - %i fields read expecting 289",field);
+    if (field < statusResponseRawMin) {
+        debugE("Throwing exception - %i fields read expecting at least %i",field, statusResponseRawMin);
         return false;
     }
 
@@ -263,202 +283,202 @@ void SpaNetInterface::clearUpdateCallback() {
 
 void SpaNetInterface::updateMeasures() {
     #pragma region R2
-    update_MainsCurrent(statusResponseRaw[2]);
-    update_MainsVoltage(statusResponseRaw[3]);
-    update_CaseTemperature(statusResponseRaw[4]);
-    update_PortCurrent(statusResponseRaw[5]);
-    // Not implemented - update_SpaTime(statusResponseRaw[12]+"-"+statusResponseRaw[11]+"-"+statusResponseRaw[10]+" "+statusResponseRaw[9]+":"+statusResponseRaw[8]+":"+statusResponseRaw[7]);
-    update_HeaterTemperature(statusResponseRaw[13]);
-    update_PoolTemperature(statusResponseRaw[14]);
-    update_WaterPresent(statusResponseRaw[15]);
-    update_AwakeMinutesRemaining(statusResponseRaw[17]);
-    update_FiltPumpRunTimeTotal(statusResponseRaw[18]);
-    update_FiltPumpReqMins(statusResponseRaw[19]);
-    update_LoadTimeOut(statusResponseRaw[20]);
-    update_HourMeter(statusResponseRaw[21]);
-    update_Relay1(statusResponseRaw[22]);
-    update_Relay2(statusResponseRaw[23]);
-    update_Relay3(statusResponseRaw[24]);
-    update_Relay4(statusResponseRaw[25]);
-    update_Relay5(statusResponseRaw[26]);
-    update_Relay6(statusResponseRaw[27]);
-    update_Relay7(statusResponseRaw[28]);
-    update_Relay8(statusResponseRaw[29]);
-    update_Relay9(statusResponseRaw[30]); 
+    update_MainsCurrent(statusResponseRaw[R2+1]);
+    update_MainsVoltage(statusResponseRaw[R2+2]);
+    update_CaseTemperature(statusResponseRaw[R2+3]);
+    update_PortCurrent(statusResponseRaw[R2+4]);
+    // Not implemented - update_SpaTime(statusResponseRaw[R2+11]+"-"+statusResponseRaw[R2+10]+"-"+statusResponseRaw[R2+9]+" "+statusResponseRaw[R2+8]+":"+statusResponseRaw[R2+7]+":"+statusResponseRaw[R2+6]);
+    update_HeaterTemperature(statusResponseRaw[R2+12]);
+    update_PoolTemperature(statusResponseRaw[R2+13]);
+    update_WaterPresent(statusResponseRaw[R2+14]);
+    update_AwakeMinutesRemaining(statusResponseRaw[R2+16]);
+    update_FiltPumpRunTimeTotal(statusResponseRaw[R2+17]);
+    update_FiltPumpReqMins(statusResponseRaw[R2+18]);
+    update_LoadTimeOut(statusResponseRaw[R2+19]);
+    update_HourMeter(statusResponseRaw[R2+20]);
+    update_Relay1(statusResponseRaw[R2+21]);
+    update_Relay2(statusResponseRaw[R2+22]);
+    update_Relay3(statusResponseRaw[R2+23]);
+    update_Relay4(statusResponseRaw[R2+24]);
+    update_Relay5(statusResponseRaw[R2+25]);
+    update_Relay6(statusResponseRaw[R2+26]);
+    update_Relay7(statusResponseRaw[R2+27]);
+    update_Relay8(statusResponseRaw[R2+28]);
+    update_Relay9(statusResponseRaw[R2+29]); 
     #pragma endregion
     #pragma region R3
-    update_CLMT(statusResponseRaw[34]);
-    update_PHSE(statusResponseRaw[35]);
-    update_LLM1(statusResponseRaw[36]);
-    update_LLM2(statusResponseRaw[37]);
-    update_LLM3(statusResponseRaw[38]);
-    update_SVER(statusResponseRaw[39]);
-    update_Model(statusResponseRaw[40]); 
-    update_SerialNo1(statusResponseRaw[41]);
-    update_SerialNo2(statusResponseRaw[42]); 
-    update_D1(statusResponseRaw[43]);
-    update_D2(statusResponseRaw[44]);
-    update_D3(statusResponseRaw[45]);
-    update_D4(statusResponseRaw[46]);
-    update_D5(statusResponseRaw[47]);
-    update_D6(statusResponseRaw[48]);
-    update_Pump(statusResponseRaw[49]);
-    update_LS(statusResponseRaw[50]);
-    update_HV(statusResponseRaw[51]);
-    update_SnpMR(statusResponseRaw[52]);
-    update_Status(statusResponseRaw[53]);
-    update_PrimeCount(statusResponseRaw[54]);
-    update_EC(statusResponseRaw[55]);
-    update_HAMB(statusResponseRaw[56]);
-    update_HCON(statusResponseRaw[57]);
-    // update_HV_2(statusResponseRaw[58]);
+    update_CLMT(statusResponseRaw[R3+1]);
+    update_PHSE(statusResponseRaw[R3+2]);
+    update_LLM1(statusResponseRaw[R3+3]);
+    update_LLM2(statusResponseRaw[R3+4]);
+    update_LLM3(statusResponseRaw[R3+5]);
+    update_SVER(statusResponseRaw[R3+6]);
+    update_Model(statusResponseRaw[R3+7]); 
+    update_SerialNo1(statusResponseRaw[R3+8]);
+    update_SerialNo2(statusResponseRaw[R3+9]); 
+    update_D1(statusResponseRaw[R3+10]);
+    update_D2(statusResponseRaw[R3+11]);
+    update_D3(statusResponseRaw[R3+12]);
+    update_D4(statusResponseRaw[R3+13]);
+    update_D5(statusResponseRaw[R3+14]);
+    update_D6(statusResponseRaw[R3+15]);
+    update_Pump(statusResponseRaw[R3+16]);
+    update_LS(statusResponseRaw[R3+17]);
+    update_HV(statusResponseRaw[R3+18]);
+    update_SnpMR(statusResponseRaw[R3+19]);
+    update_Status(statusResponseRaw[R3+20]);
+    update_PrimeCount(statusResponseRaw[R3+21]);
+    update_EC(statusResponseRaw[R3+22]);
+    update_HAMB(statusResponseRaw[R3+23]);
+    update_HCON(statusResponseRaw[R3+24]);
+    // update_HV_2(statusResponseRaw[R3+25]);
     #pragma endregion
     #pragma region R4
-    update_Mode(statusResponseRaw[63]);
-    update_Ser1_Timer(statusResponseRaw[64]);
-    update_Ser2_Timer(statusResponseRaw[65]);
-    update_Ser3_Timer(statusResponseRaw[66]);
-    update_HeatMode(statusResponseRaw[67]);
-    update_PumpIdleTimer(statusResponseRaw[68]);
-    update_PumpRunTimer(statusResponseRaw[69]);
-    update_AdtPoolHys(statusResponseRaw[70]);
-    update_AdtHeaterHys(statusResponseRaw[71]);
-    update_Power(statusResponseRaw[72]);
-    update_Power_kWh(statusResponseRaw[73]);
-    update_Power_Today(statusResponseRaw[74]);
-    update_Power_Yesterday(statusResponseRaw[75]);
-    update_ThermalCutOut(statusResponseRaw[76]);
-    update_Test_D1(statusResponseRaw[77]);
-    update_Test_D2(statusResponseRaw[78]);
-    update_Test_D3(statusResponseRaw[79]);
-    update_ElementHeatSourceOffset(statusResponseRaw[80]);
-    update_Frequency(statusResponseRaw[81]);
-    update_HPHeatSourceOffset_Heat(statusResponseRaw[82]);
-    update_HPHeatSourceOffset_Cool(statusResponseRaw[83]);
-    update_HeatSourceOffTime(statusResponseRaw[84]);
-    update_Vari_Speed(statusResponseRaw[86]);
-    update_Vari_Percent(statusResponseRaw[87]);
-    update_Vari_Mode(statusResponseRaw[85]);
+    update_Mode(statusResponseRaw[67]);
+    update_Ser1_Timer(statusResponseRaw[68]);
+    update_Ser2_Timer(statusResponseRaw[69]);
+    update_Ser3_Timer(statusResponseRaw[70]);
+    update_HeatMode(statusResponseRaw[71]);
+    update_PumpIdleTimer(statusResponseRaw[72]);
+    update_PumpRunTimer(statusResponseRaw[73]);
+    update_AdtPoolHys(statusResponseRaw[74]);
+    update_AdtHeaterHys(statusResponseRaw[75]);
+    update_Power(statusResponseRaw[76]);
+    update_Power_kWh(statusResponseRaw[77]);
+    update_Power_Today(statusResponseRaw[78]);
+    update_Power_Yesterday(statusResponseRaw[79]);
+    update_ThermalCutOut(statusResponseRaw[80]);
+    update_Test_D1(statusResponseRaw[81]);
+    update_Test_D2(statusResponseRaw[82]);
+    update_Test_D3(statusResponseRaw[83]);
+    update_ElementHeatSourceOffset(statusResponseRaw[84]);
+    update_Frequency(statusResponseRaw[85]);
+    update_HPHeatSourceOffset_Heat(statusResponseRaw[86]);
+    update_HPHeatSourceOffset_Cool(statusResponseRaw[87]);
+    update_HeatSourceOffTime(statusResponseRaw[88]);
+    update_Vari_Speed(statusResponseRaw[90]);
+    update_Vari_Percent(statusResponseRaw[91]);
+    update_Vari_Mode(statusResponseRaw[89]);
     #pragma endregion
     #pragma region R5
     //R5
     // Unknown encoding - TouchPad2.updateValue();
     // Unknown encoding - TouchPad1.updateValue();
-    update_RB_TP_Pump1(statusResponseRaw[110]);
-    update_RB_TP_Pump2(statusResponseRaw[111]);
-    update_RB_TP_Pump3(statusResponseRaw[112]);
-    update_RB_TP_Pump4(statusResponseRaw[113]);
-    update_RB_TP_Pump5(statusResponseRaw[114]);
-    //RB_TP_Blower.updateValue(statusResponseRaw[101]);
-    //RB_TP_Light.updateValue(statusResponseRaw[102]);
-    update_RB_TP_Auto(statusResponseRaw[105]);
-    update_RB_TP_Heater(statusResponseRaw[104]);
-    update_RB_TP_Ozone(statusResponseRaw[103]);
-    update_RB_TP_Sleep(statusResponseRaw[102]);
-    update_WTMP(statusResponseRaw[107]);
-    update_CleanCycle(statusResponseRaw[108]);
+    //RB_TP_Blower.updateValue(statusResponseRaw[R5 + 5]);
+    update_RB_TP_Sleep(statusResponseRaw[R5 + 10]);
+    update_RB_TP_Ozone(statusResponseRaw[R5 + 11]);
+    update_RB_TP_Heater(statusResponseRaw[R5 + 12]);
+    update_RB_TP_Auto(statusResponseRaw[R5 + 13]);
+    //RB_TP_Light.updateValue(statusResponseRaw[R5 + 14]);
+    update_WTMP(statusResponseRaw[R5 + 15]);
+    update_CleanCycle(statusResponseRaw[R5 + 16]);
+    update_RB_TP_Pump1(statusResponseRaw[R5 + 18]);
+    update_RB_TP_Pump2(statusResponseRaw[R5 + 19]);
+    update_RB_TP_Pump3(statusResponseRaw[R5 + 20]);
+    update_RB_TP_Pump4(statusResponseRaw[R5 + 21]);
+    update_RB_TP_Pump5(statusResponseRaw[R5 + 22]);
     #pragma endregion
     #pragma region R6
-    update_VARIValue(statusResponseRaw[121]);
-    update_LBRTValue(statusResponseRaw[122]);
-    update_CurrClr(statusResponseRaw[123]);
-    update_ColorMode(statusResponseRaw[124]);
-    update_LSPDValue(statusResponseRaw[125]);
-    update_FiltSetHrs(statusResponseRaw[126]);
-    update_FiltBlockHrs(statusResponseRaw[127]);
-    update_STMP(statusResponseRaw[128]);
-    update_L_24HOURS(statusResponseRaw[129]);
-    update_PSAV_LVL(statusResponseRaw[130]);
-    update_PSAV_BGN(statusResponseRaw[131]);
-    update_PSAV_END(statusResponseRaw[132]);
-    update_L_1SNZ_DAY(statusResponseRaw[133]);
-    update_L_2SNZ_DAY(statusResponseRaw[134]);
-    update_L_1SNZ_BGN(statusResponseRaw[135]);
-    update_L_2SNZ_BGN(statusResponseRaw[136]);
-    update_L_1SNZ_END(statusResponseRaw[137]);
-    update_L_2SNZ_END(statusResponseRaw[138]);
-    update_DefaultScrn(statusResponseRaw[139]);
-    update_TOUT(statusResponseRaw[140]);
-    update_VPMP(statusResponseRaw[141]);
-    update_HIFI(statusResponseRaw[142]);
-    update_BRND(statusResponseRaw[143]);
-    update_PRME(statusResponseRaw[144]);
-    update_ELMT(statusResponseRaw[145]);
-    update_TYPE(statusResponseRaw[146]);
-    update_GAS(statusResponseRaw[147]);
+    update_VARIValue(statusResponseRaw[R6 + 1]);
+    update_LBRTValue(statusResponseRaw[R6 + 2]);
+    update_CurrClr(statusResponseRaw[R6 + 3]);
+    update_ColorMode(statusResponseRaw[R6 + 4]);
+    update_LSPDValue(statusResponseRaw[R6 + 5]);
+    update_FiltSetHrs(statusResponseRaw[R6 + 6]);
+    update_FiltBlockHrs(statusResponseRaw[R6 + 7]);
+    update_STMP(statusResponseRaw[R6 + 8]);
+    update_L_24HOURS(statusResponseRaw[R6 + 9]);
+    update_PSAV_LVL(statusResponseRaw[R6 + 10]);
+    update_PSAV_BGN(statusResponseRaw[R6 + 11]);
+    update_PSAV_END(statusResponseRaw[R6 + 12]);
+    update_L_1SNZ_DAY(statusResponseRaw[R6 + 13]);
+    update_L_2SNZ_DAY(statusResponseRaw[R6 + 14]);
+    update_L_1SNZ_BGN(statusResponseRaw[R6 + 15]);
+    update_L_2SNZ_BGN(statusResponseRaw[R6 + 16]);
+    update_L_1SNZ_END(statusResponseRaw[R6 + 17]);
+    update_L_2SNZ_END(statusResponseRaw[R6 + 18]);
+    update_DefaultScrn(statusResponseRaw[R6 + 19]);
+    update_TOUT(statusResponseRaw[R6 + 20]);
+    update_VPMP(statusResponseRaw[R6 + 21]);
+    update_HIFI(statusResponseRaw[R6 + 22]);
+    update_BRND(statusResponseRaw[R6 + 23]);
+    update_PRME(statusResponseRaw[R6 + 24]);
+    update_ELMT(statusResponseRaw[R6 + 25]);
+    update_TYPE(statusResponseRaw[R6 + 26]);
+    update_GAS(statusResponseRaw[R6 + 27]);
     #pragma endregion
     #pragma region R7
-    update_WCLNTime(statusResponseRaw[151]);
+    update_WCLNTime(statusResponseRaw[R7 + 1]);
     // The following 2 may be reversed
-    update_TemperatureUnits(statusResponseRaw[153]);
-    update_OzoneOff(statusResponseRaw[152]);
-    update_Ozone24(statusResponseRaw[154]);
-    update_Circ24(statusResponseRaw[156]);
-    update_CJET(statusResponseRaw[155]);
+    update_TemperatureUnits(statusResponseRaw[R7 + 3]);
+    update_OzoneOff(statusResponseRaw[R7 + 2]);
+    update_Ozone24(statusResponseRaw[R7 + 4]);
+    update_Circ24(statusResponseRaw[R7 + 6]);
+    update_CJET(statusResponseRaw[R7 + 5]);
     // 0 = off, 1 = step, 2 = variable
-    update_VELE(statusResponseRaw[157]);
-    //update_StartDD(statusResponseRaw[158]);
-    //update_StartMM(statusResponseRaw[159]);
-    //update_StartYY(statusResponseRaw[160]);
-    update_V_Max(statusResponseRaw[161]);
-    update_V_Min(statusResponseRaw[162]);
-    update_V_Max_24(statusResponseRaw[163]);
-    update_V_Min_24(statusResponseRaw[164]);
-    update_CurrentZero(statusResponseRaw[165]);
-    update_CurrentAdjust(statusResponseRaw[166]);
-    update_VoltageAdjust(statusResponseRaw[167]);
+    update_VELE(statusResponseRaw[R7 + 7]);
+    //update_StartDD(statusResponseRaw[R7 + 8]);
+    //update_StartMM(statusResponseRaw[R7 + 9]);
+    //update_StartYY(statusResponseRaw[R7 + 10]);
+    update_V_Max(statusResponseRaw[R7 + 11]);
+    update_V_Min(statusResponseRaw[R7 + 12]);
+    update_V_Max_24(statusResponseRaw[R7 + 13]);
+    update_V_Min_24(statusResponseRaw[R7 + 14]);
+    update_CurrentZero(statusResponseRaw[R7 + 15]);
+    update_CurrentAdjust(statusResponseRaw[R7 + 16]);
+    update_VoltageAdjust(statusResponseRaw[R7 + 17]);
     // 168 is unknown
-    update_Ser1(statusResponseRaw[169]);
-    update_Ser2(statusResponseRaw[170]);
-    update_Ser3(statusResponseRaw[171]);
-    update_VMAX(statusResponseRaw[172]);
-    update_AHYS(statusResponseRaw[173]);
-    update_HUSE(statusResponseRaw[174]);
-    update_HELE(statusResponseRaw[175]);
-    update_HPMP(statusResponseRaw[176]);
-    update_PMIN(statusResponseRaw[177]);
-    update_PFLT(statusResponseRaw[178]);
-    update_PHTR(statusResponseRaw[179]);
-    update_PMAX(statusResponseRaw[180]);
+    update_Ser1(statusResponseRaw[R7 + 19]);
+    update_Ser2(statusResponseRaw[R7 + 20]);
+    update_Ser3(statusResponseRaw[R7 + 21]);
+    update_VMAX(statusResponseRaw[R7 + 22]);
+    update_AHYS(statusResponseRaw[R7 + 23]);
+    update_HUSE(statusResponseRaw[R7 + 24]);
+    update_HELE(statusResponseRaw[R7 + 25]);
+    update_HPMP(statusResponseRaw[R7 + 26]);
+    update_PMIN(statusResponseRaw[R7 + 27]);
+    update_PFLT(statusResponseRaw[R7 + 28]);
+    update_PHTR(statusResponseRaw[R7 + 29]);
+    update_PMAX(statusResponseRaw[R7 + 30]);
     #pragma endregion
     #pragma region R9
-    update_F1_HR(statusResponseRaw[185]);
-    update_F1_Time(statusResponseRaw[186]);
-    update_F1_ER(statusResponseRaw[187]);
-    update_F1_I(statusResponseRaw[188]);
-    update_F1_V(statusResponseRaw[189]);
-    update_F1_PT(statusResponseRaw[190]);
-    update_F1_HT(statusResponseRaw[191]);
-    update_F1_CT(statusResponseRaw[192]);
-    update_F1_PU(statusResponseRaw[193]);
-    update_F1_VE(statusResponseRaw[194]);
-    update_F1_ST(statusResponseRaw[195]);
+    update_F1_HR(statusResponseRaw[R9 + 2]);
+    update_F1_Time(statusResponseRaw[R9 + 3]);
+    update_F1_ER(statusResponseRaw[R9 + 4]);
+    update_F1_I(statusResponseRaw[R9 + 5]);
+    update_F1_V(statusResponseRaw[R9 + 6]);
+    update_F1_PT(statusResponseRaw[R9 + 7]);
+    update_F1_HT(statusResponseRaw[R9 + 8]);
+    update_F1_CT(statusResponseRaw[R9 + 9]);
+    update_F1_PU(statusResponseRaw[R9 + 10]);
+    update_F1_VE(statusResponseRaw[R9 + 11]);
+    update_F1_ST(statusResponseRaw[R9 + 12]);
     #pragma endregion
     #pragma region RA
-    update_F2_HR(statusResponseRaw[199]);
-    update_F2_Time(statusResponseRaw[200]);
-    update_F2_ER(statusResponseRaw[201]);
-    update_F2_I(statusResponseRaw[202]);
-    update_F2_V(statusResponseRaw[203]);
-    update_F2_PT(statusResponseRaw[204]);
-    update_F2_HT(statusResponseRaw[205]);
-    update_F2_CT(statusResponseRaw[206]);
-    update_F2_PU(statusResponseRaw[207]);
-    update_F2_VE(statusResponseRaw[208]);
-    update_F2_ST(statusResponseRaw[209]);
+    update_F2_HR(statusResponseRaw[RA + 2]);
+    update_F2_Time(statusResponseRaw[RA + 3]);
+    update_F2_ER(statusResponseRaw[RA + 4]);
+    update_F2_I(statusResponseRaw[RA + 5]);
+    update_F2_V(statusResponseRaw[RA + 6]);
+    update_F2_PT(statusResponseRaw[RA + 7]);
+    update_F2_HT(statusResponseRaw[RA + 8]);
+    update_F2_CT(statusResponseRaw[RA + 9]);
+    update_F2_PU(statusResponseRaw[RA + 10]);
+    update_F2_VE(statusResponseRaw[RA + 11]);
+    update_F2_ST(statusResponseRaw[RA + 12]);
     #pragma endregion
     #pragma region RB
-    update_F3_HR(statusResponseRaw[213]);
-    update_F3_Time(statusResponseRaw[214]);
-    update_F3_ER(statusResponseRaw[215]);
-    update_F3_I(statusResponseRaw[216]);
-    update_F3_V(statusResponseRaw[217]);
-    update_F3_PT(statusResponseRaw[218]);
-    update_F3_HT(statusResponseRaw[219]);
-    update_F3_CT(statusResponseRaw[220]);
-    update_F3_PU(statusResponseRaw[221]);
-    update_F3_VE(statusResponseRaw[222]);
-    update_F3_ST(statusResponseRaw[223]);
+    update_F3_HR(statusResponseRaw[RB + 2]);
+    update_F3_Time(statusResponseRaw[RB + 3]);
+    update_F3_ER(statusResponseRaw[RB + 4]);
+    update_F3_I(statusResponseRaw[RB + 5]);
+    update_F3_V(statusResponseRaw[RB + 6]);
+    update_F3_PT(statusResponseRaw[RB + 7]);
+    update_F3_HT(statusResponseRaw[RB + 8]);
+    update_F3_CT(statusResponseRaw[RB + 9]);
+    update_F3_PU(statusResponseRaw[RB + 10]);
+    update_F3_VE(statusResponseRaw[RB + 11]);
+    update_F3_ST(statusResponseRaw[RB + 12]);
     #pragma endregion
     #pragma region RC
     //Outlet_Heater.updateValue(statusResponseRaw[]);
@@ -468,10 +488,10 @@ void SpaNetInterface::updateMeasures() {
     //Outlet_Pump2.updateValue(statusResponseRaw[]);
     //Outlet_Pump4.updateValue(statusResponseRaw[]);
     //Outlet_Pump5.updateValue(statusResponseRaw[]);
-    update_Outlet_Blower(statusResponseRaw[235]);
+    update_Outlet_Blower(statusResponseRaw[RC + 10]);
     #pragma endregion
     #pragma region RE
-    update_HP_Present(statusResponseRaw[242]);
+    update_HP_Present(statusResponseRaw[RE + 1]);
     //HP_FlowSwitch.updateValue(statusResponseRaw[]);
     //HP_HighSwitch.updateValue(statusResponseRaw[]);
     //HP_LowSwitch.updateValue(statusResponseRaw[]);
@@ -480,44 +500,44 @@ void SpaNetInterface::updateMeasures() {
     //HP_D1.updateValue(statusResponseRaw[]);
     //HP_D2.updateValue(statusResponseRaw[]);
     //HP_D3.updateValue(statusResponseRaw[]);
-    update_HP_Ambient(statusResponseRaw[251]);
-    update_HP_Condensor(statusResponseRaw[252]);
-    update_HP_Compressor_State(statusResponseRaw[253]);
-    update_HP_Fan_State(statusResponseRaw[254]);
-    update_HP_4W_Valve(statusResponseRaw[255]);
-    update_HP_Heater_State(statusResponseRaw[256]);
-    update_HP_State(statusResponseRaw[257]);
-    update_HP_Mode(statusResponseRaw[258]);
-    update_HP_Defrost_Timer(statusResponseRaw[259]);
-    update_HP_Comp_Run_Timer(statusResponseRaw[260]);
-    update_HP_Low_Temp_Timer(statusResponseRaw[261]);
-    update_HP_Heat_Accum_Timer(statusResponseRaw[262]);
-    update_HP_Sequence_Timer(statusResponseRaw[263]);
-    update_HP_Warning(statusResponseRaw[264]);
-    update_FrezTmr(statusResponseRaw[265]);
-    update_DBGN(statusResponseRaw[266]);
-    update_DEND(statusResponseRaw[267]);
-    update_DCMP(statusResponseRaw[268]);
-    update_DMAX(statusResponseRaw[269]);
-    update_DELE(statusResponseRaw[270]);
-    update_DPMP(statusResponseRaw[271]);
+    update_HP_Ambient(statusResponseRaw[RE + 10]);
+    update_HP_Condensor(statusResponseRaw[RE + 11]);
+    update_HP_Compressor_State(statusResponseRaw[RE + 12]);
+    update_HP_Fan_State(statusResponseRaw[RE + 13]);
+    update_HP_4W_Valve(statusResponseRaw[RE + 14]);
+    update_HP_Heater_State(statusResponseRaw[RE + 15]);
+    update_HP_State(statusResponseRaw[RE + 16]);
+    update_HP_Mode(statusResponseRaw[RE + 17]);
+    update_HP_Defrost_Timer(statusResponseRaw[RE + 18]);
+    update_HP_Comp_Run_Timer(statusResponseRaw[RE + 19]);
+    update_HP_Low_Temp_Timer(statusResponseRaw[RE + 20]);
+    update_HP_Heat_Accum_Timer(statusResponseRaw[RE + 21]);
+    update_HP_Sequence_Timer(statusResponseRaw[RE + 22]);
+    update_HP_Warning(statusResponseRaw[RE + 23]);
+    update_FrezTmr(statusResponseRaw[RE + 24]);
+    update_DBGN(statusResponseRaw[RE + 25]);
+    update_DEND(statusResponseRaw[RE + 26]);
+    update_DCMP(statusResponseRaw[RE + 27]);
+    update_DMAX(statusResponseRaw[RE + 28]);
+    update_DELE(statusResponseRaw[RE + 29]);
+    update_DPMP(statusResponseRaw[RE + 30]);
     //CMAX.updateValue(statusResponseRaw[]);
     //HP_Compressor.updateValue(statusResponseRaw[]);
     //HP_Pump_State.updateValue(statusResponseRaw[]);
     //HP_Status.updateValue(statusResponseRaw[]);
     #pragma endregion
     #pragma region RG
-    update_Pump1InstallState(statusResponseRaw[280]);
-    update_Pump2InstallState(statusResponseRaw[281]);
-    update_Pump3InstallState(statusResponseRaw[282]);
-    update_Pump4InstallState(statusResponseRaw[283]);
-    update_Pump5InstallState(statusResponseRaw[284]);
-    update_Pump1OkToRun(statusResponseRaw[274]);
-    update_Pump2OkToRun(statusResponseRaw[275]);
-    update_Pump3OkToRun(statusResponseRaw[276]);
-    update_Pump4OkToRun(statusResponseRaw[277]);
-    update_Pump5OkToRun(statusResponseRaw[278]);
-    update_LockMode(statusResponseRaw[285]);
+    update_Pump1InstallState(statusResponseRaw[RG + 7]);
+    update_Pump2InstallState(statusResponseRaw[RG + 8]);
+    update_Pump3InstallState(statusResponseRaw[RG + 9]);
+    update_Pump4InstallState(statusResponseRaw[RG + 10]);
+    update_Pump5InstallState(statusResponseRaw[RG + 11]);
+    update_Pump1OkToRun(statusResponseRaw[RG + 1]);
+    update_Pump2OkToRun(statusResponseRaw[RG + 2]);
+    update_Pump3OkToRun(statusResponseRaw[RG + 3]);
+    update_Pump4OkToRun(statusResponseRaw[RG + 4]);
+    update_Pump5OkToRun(statusResponseRaw[RG + 5]);
+    update_LockMode(statusResponseRaw[RG + 12]);
     #pragma endregion
 
 };

--- a/lib/SpaNetInterface/SpaNetInterface.h
+++ b/lib/SpaNetInterface/SpaNetInterface.h
@@ -17,9 +17,27 @@ extern RemoteDebug Debug;
 class SpaNetInterface : public SpaNetProperties {
     private:
 
-        /// @brief Each field of the RF cmd response as seperate elements.
-        String statusResponseRaw[290];
+        /// @brief Minimum number of fields in status response for it to be considered valid.
+        int statusResponseRawMin = 288;
 
+        /// @brief Maximum number of fields in status response.
+        int statusResponseRawMax = 350;
+
+        /// @brief Each field of the RF cmd response as seperate elements.
+        String statusResponseRaw[350];
+
+        int R2;
+        int R3;
+        int R4;
+        int R5;
+        int R6;
+        int R7;
+        int R9;
+        int RA;
+        int RB;
+        int RC;
+        int RE;
+        int RG;
 
         /// @brief Does the status response array contain valid information?
         bool validStatusResponse = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,13 +29,13 @@
 //#define NUM(a) (sizeof(a) / sizeof(*a)) //number of elements in an array
 
 #if defined(ESP8266)
-  #define PIN_D0 D0
+  #define EN_PIN D0 //Note: D0 seems to latch LOW when the USB cable is connected. Change to D1 if needed.
 #elif defined(ESP32)
-  #define PIN_D0 0
+  #define EN_PIN 0
   const int LED_BUILTIN = 2;
 #endif
 
-const int TRIGGER_PIN = PIN_D0;
+const int TRIGGER_PIN = EN_PIN;
 
 
 #ifndef DEBUG_ENABLED
@@ -692,8 +692,10 @@ void mqttPublishStatus() {
 void setup() {
   pinMode(TRIGGER_PIN, INPUT_PULLUP);
 
+#if defined(ESP32)
   Serial.begin(115200);
   Serial.setDebugOutput(true);
+#endif
 
   delay(200);
 
@@ -703,7 +705,9 @@ void setup() {
   Debug.begin(WiFi.getHostname());
   Debug.setResetCmdEnabled(true);
   Debug.showProfiler(true);
+#if defined(ESP32)
   Debug.setSerialEnabled(true);
+#endif
 
   debugA("Starting...");
 


### PR DESCRIPTION
The first commit has changes to enable ESP D1 mini to use its hardware serial. Note: you can only use D8 & D7 for the hardware serial.

The second commit updates the readStatus function in SpaNetInterface to use the "Rn" markers to read the values. Using this enables the code to support multiple spa controllers.

To do:
1. add a picture for ESP D1 mini wiring
2. Double check register values against what is documented here: https://github.com/BlaT2512/spanet-api/blob/main/spanet.md#6-reading-spa-data

You could wait until I've done the above until accepting this pull request, but I wanted to make the updates available for you to comment on :)