### PR TITLE
platformio updates

### DIFF
--- a/lib/SpaInterface/SpaInterface.cpp
+++ b/lib/SpaInterface/SpaInterface.cpp
@@ -40,7 +40,7 @@ void SpaInterface::sendCommand(String cmd) {
     port.print('\n');
     port.flush();
     delay(50); // **TODO** is this needed?
-    port.printf("%s\n", cmd);
+    port.printf("%s\n", cmd.c_str());
     port.flush();
 
     long timeout = millis() + 1000; // wait up to 1 sec for a response
@@ -390,7 +390,7 @@ bool SpaInterface::readStatus() {
     while (field < statusResponseExpectedFields)
     {
         statusResponseRaw[field] = port.readStringUntil(',');
-        debugV("(%i,%s)",field,statusResponseRaw[field]);
+        debugV("(%i,%s)",field,statusResponseRaw[field].c_str());
 
         statusResponseTmp = statusResponseTmp + statusResponseRaw[field]+",";
 
@@ -399,7 +399,7 @@ bool SpaInterface::readStatus() {
             return false;
         }
         if (field == 0 && !statusResponseRaw[field].startsWith("RF:")) { // If the first field is not "RF:" stop we don't have the start of the register
-            debugE("Throwing exception - field: %i, value: %s", field, statusResponseRaw[field]);
+            debugE("Throwing exception - field: %i, value: %s", field, statusResponseRaw[field].c_str());
             return false;
         }
 

--- a/lib/SpaInterface/SpaInterface.cpp
+++ b/lib/SpaInterface/SpaInterface.cpp
@@ -2,9 +2,6 @@
 
 #define BAUD_RATE 38400
 
-SpaInterface::SpaInterface(Stream &p) : port(p) {
-}
-
 SpaInterface::SpaInterface() : port(SPA_SERIAL) {
     #if defined(ESP8266)
         SPA_SERIAL.setRxBufferSize(1024);  //required for unit testing

--- a/lib/SpaInterface/SpaInterface.cpp
+++ b/lib/SpaInterface/SpaInterface.cpp
@@ -2,26 +2,20 @@
 
 #define BAUD_RATE 38400
 
-#if defined(ESP8266)
-    HardwareSerial spaSerial = Serial;
-#elif defined(ESP32)
-    HardwareSerial spaSerial = Serial2;
-#endif
-
 SpaInterface::SpaInterface(Stream &p) : port(p) {
 }
 
-SpaInterface::SpaInterface() : port(spaSerial) {
+SpaInterface::SpaInterface() : port(SPA_SERIAL) {
     #if defined(ESP8266)
-        spaSerial.setRxBufferSize(1024);  //required for unit testing
-        spaSerial.begin(BAUD_RATE);
-        spaSerial.pins(TX_PIN, RX_PIN);
+        SPA_SERIAL.setRxBufferSize(1024);  //required for unit testing
+        SPA_SERIAL.begin(BAUD_RATE);
+        SPA_SERIAL.pins(TX_PIN, RX_PIN);
     #elif defined(ESP32)
-        spaSerial.setRxBufferSize(1024);  //required for unit testing
-        spaSerial.setTxBufferSize(1024);  //required for unit testing
-        spaSerial.begin(BAUD_RATE, SERIAL_8N1, RX_PIN, TX_PIN);
+        SPA_SERIAL.setRxBufferSize(1024);  //required for unit testing
+        SPA_SERIAL.setTxBufferSize(1024);  //required for unit testing
+        SPA_SERIAL.begin(BAUD_RATE, SERIAL_8N1, RX_PIN, TX_PIN);
     #endif
-    spaSerial.setTimeout(250);
+    SPA_SERIAL.setTimeout(250);
 }
 
 SpaInterface::~SpaInterface() {}

--- a/lib/WebUI/WebUI.cpp
+++ b/lib/WebUI/WebUI.cpp
@@ -28,7 +28,7 @@ void WebUI::begin() {
         server->sendHeader("Connection", "close");
         char buffer[1024];
         SpaInterface &si = *_spa;
-        float current_temp = (si.getWTMP() / 10);
+        float current_temp = float(si.getWTMP()) / 10;
         String status = si.getStatus();
         sprintf(buffer, indexPageTemplate, current_temp, status);
         server->send(200, "text/html", buffer);

--- a/platformio.ini
+++ b/platformio.ini
@@ -33,7 +33,8 @@ build_flags =
   -D RX_PIN=16
   -D TX_PIN=17
   -D EN_PIN=0
-  -D LED_BUILTIN=2
+  -D LED_PIN=2
+  -D SPA_SERIAL=Serial2
 
 [env:esp8266dev]
 extends = env:spa-base
@@ -42,7 +43,8 @@ board = d1_mini
 build_flags =
   -D RX_PIN=13
   -D TX_PIN=15
-  -D EN_PIN=D0
+  -D LED_PIN=LED_BUILTIN
+  -D SPA_SERIAL=Serial
 
 [env:spa-control-pcb]
 extends = env:spa-base
@@ -51,7 +53,8 @@ board = esp32-s3-devkitc-1
 build_flags =
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -D SPACTRLPCB=1
-  -D LED_BUILTIN=2
   -D RX_PIN=16
-  -D TX_PIN=17
+  -D TX_PIN=15
   -D EN_PIN=0
+  -D LED_PIN=14
+  -D SPA_SERIAL=Serial2

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,7 +79,7 @@ String convertToTime(int data) {
                    String(minutes / 10) + String(minutes % 10);
 
   // Print debug information
-  debugV("data: %i, timeStr %s", data, timeStr);
+  debugV("data: %i, timeStr: %s", data, timeStr.c_str());
 
   return timeStr;
 }
@@ -108,7 +108,7 @@ int convertToInteger(const String& timeStr) {
   }
 
   // Print debug information
-  debugV("data: %i, timeStr %s", data, timeStr);
+  debugV("data: %i, timeStr: %s", data, timeStr.c_str());
 
   return data;
 }
@@ -905,11 +905,12 @@ void mqttCallback(char* topic, byte* payload, unsigned int length) {
     si.setOutlet_Blower(p=="Variable"?0:1);
   } else if (property == "sleepTimers_1_state" || property == "sleepTimers_2_state") {
     for (int count = 0; count < sizeof(si.sleepStringMap); count++){
-      if (si.sleepStringMap[count] == p)
+      if (si.sleepStringMap[count] == p) {
         if (property == "sleepTimers_1_state")
           si.setL_1SNZ_DAY(si.sleepCodeMap[count]);
         else if (property == "sleepTimers_2_state")
           si.setL_2SNZ_DAY(si.sleepCodeMap[count]);
+      }
     }
   } else if (property == "sleepTimers_1_begin") {
     si.setL_1SNZ_BGN(convertToInteger(p));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,9 +19,9 @@
 #include <vector>
 #include <Time.h>
 #include <TimeLib.h>
-
+#if defined(LED_PIN)
 #include "Blinker.h"
-
+#endif
 #include "WebUI.h"
 
 #include "SpaInterface.h"
@@ -33,8 +33,9 @@
 
 SpaInterface si;
 
-
+#if defined(LED_PIN)
 Blinker led(LED_PIN);
+#endif
 WiFiClient wifi;
 PubSubClient mqttClient(wifi);
 
@@ -1006,7 +1007,9 @@ void loop() {
 
 
   checkButton();
+  #if defined(LED_PIN)
   led.tick();
+  #endif
   mqttClient.loop();
   Debug.handle();
 
@@ -1016,7 +1019,9 @@ void loop() {
 
   if (WiFi.status() != WL_CONNECTED) {
     //wifi not connected
+    #if defined(LED_PIN)
     led.setInterval(100);
+    #endif
     long now = millis();
     if (now-wifiLastConnect > 10000) {
       debugI("Wifi reconnecting...");
@@ -1044,7 +1049,9 @@ void loop() {
         if (!mqttClient.connected()) {  // MQTT broker reconnect if not connected
           long now=millis();
           if (now - mqttLastConnect > 1000) {
+            #if defined(LED_PIN)
             led.setInterval(500);
+            #endif
             debugW("MQTT not connected, attempting connection to %s:%s",mqttServer.c_str(),mqttPort.c_str());
             mqttLastConnect = now;
 
@@ -1074,7 +1081,9 @@ void loop() {
             si.statusResponse.setCallback(mqttPublishStatusString);
 
           }
+          #if defined(LED_PIN)
           led.setInterval(2000);
+          #endif
         }
       }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@
 SpaInterface si;
 
 
-Blinker led(LED_BUILTIN);
+Blinker led(LED_PIN);
 WiFiClient wifi;
 PubSubClient mqttClient(wifi);
 
@@ -118,6 +118,7 @@ void saveConfigCallback(){
 
 // We check the button on D0 every loop, to allow people to restart the system 
 void checkButton(){
+#if defined(EN_PIN)
   if(digitalRead(EN_PIN) == LOW) {
     debugI("Initial buttong press detected");
     delay(100); // wait and then test again to ensure that it is a held button not a press
@@ -170,6 +171,7 @@ void checkButton(){
       ESP.restart();  // restart, dirty but easier than trying to restart services one by one
     }
   }
+#endif
 }
 
 #pragma region Auto Discovery
@@ -927,7 +929,9 @@ void mqttCallback(char* topic, byte* payload, unsigned int length) {
 #pragma endregion
 
 void setup() {
+#if defined(EN_PIN)
   pinMode(EN_PIN, INPUT_PULLUP);
+#endif
 
 #if !defined(ESP8266)
   Serial.begin(115200);


### PR DESCRIPTION
* Added SPA_SERIAL as a build flag so we can change the serial port depending on the board.
* Renamed LED_BUILTIN to LED_PIN. LED_BUILTIN is already defined for ESP8266 and ESP32-S3, and you can't define it twice. This change enables us to us the "default" (see esp8266dev example) or override it (see spa-control-pcb example).
* If EN_PIN is not set, then disable this code. The D1 mini (ESP8266) doesn't have a enable button, so now you can optionally disable it. I will add an option in a future update, to enter the Wi-Fi manager if the device is rebooted twice within (say) 20 seconds.