### PR TITLE
two updates -Wi-Fi Manager and Supporting SVM2 with older firmware

### DIFF
--- a/lib/SpaInterface/SpaInterface.h
+++ b/lib/SpaInterface/SpaInterface.h
@@ -16,17 +16,12 @@ extern RemoteDebug Debug;
 class SpaInterface : public SpaProperties {
     private:
 
-        /// @brief Number of fields that we can expect to read, initially set to 100 but updated once we determine the variant of the controller we are running.
-        int statusResponseExpectedFields = 100;
-
-
-        /// @brief Number of fields expected to be returned for a SV3
-        const int statusResponseCount_SV3 = 289;
-        /// @brief Number of fields expected to be returned for a SVM2
-        const int statusResponseCount_SVM2 = 295;
+        /// @brief Number of fields that we can expect to read.
+        int statusResponseMinFields = 289;
+        static const int statusResponseMaxFields = 295;
         
         /// @brief Each field of the RF cmd response as seperate elements.
-        String statusResponseRaw[295];
+        String statusResponseRaw[statusResponseMaxFields];
 
         int R2=-1;
         int R3=-1;

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,13 +17,12 @@ monitor_port = COM5
 monitor_speed = 115200
 lib_ldf_mode = deep
 lib_deps = 
-	https://github.com/tzapu/WiFiManager.git
-	https://github.com/ktos/RemoteDebug.git
-	knolleary/PubSubClient
-	bblanchon/ArduinoJson@^7.1.0
-	links2004/WebSockets@^2.3.6
-	paulstoffregen/Time@^1.6.1
-
+  https://github.com/ktos/RemoteDebug.git@3.0.7
+  tzapu/WiFiManager@^2.0.17
+  knolleary/PubSubClient@^2.8
+  bblanchon/ArduinoJson@^7.1.0
+  links2004/WebSockets@^2.3.6
+  paulstoffregen/Time@^1.6.1
 
 [env:esp32dev]
 extends = env:spa-base

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -142,6 +142,7 @@ void startWiFiManager(){
   wm.addParameter(&custom_mqtt_password);
   wm.setBreakAfterConfig(true);
   wm.setSaveConfigCallback(saveConfigCallback);
+  wm.setConnectTimeout(300); //close the WiFiManager after 300 seconds of inactivity
 
 
   wm.startConfigPortal();


### PR DESCRIPTION
1. There appears to be a bug in the Wi-Fi system for ESP32s that effects Wi-Fi Manager. The workaround is to set a timeout for the Wi-Fi manager. Otherwise, the Wi-Fi Manager stops after 60 seconds. See commit for link and more info.
2. Per my discord post, my new SVM2 controller has the same registers as the SV3. I have tweaked the code to support both.

The updated register code looks for ":" and increments a counter. Once we've reached 12, we've read everything. I considered another option, waiting until the counter reached statusResponseMinFields, then stopping when we reach a ":'.