### PR TITLE
Added option to have entities added to home assistant but disabled by default

### DIFF
--- a/lib/HAAutoDiscovery/HAAutoDiscovery.cpp
+++ b/lib/HAAutoDiscovery/HAAutoDiscovery.cpp
@@ -5,7 +5,8 @@ void generateCommonAdJSON(
    const AutoDiscoveryInformationTemplate& config,
    const SpaADInformationTemplate& spa,
    String& discoveryTopic,
-   String type
+   String type,
+   bool enabledByDefault
    ) {
 /*
 { 
@@ -28,6 +29,7 @@ void generateCommonAdJSON(
    json["state_topic"] = spa.stateTopic;
    json["value_template"] = config.valueTemplate;
    json["unique_id"] = spa.spaSerialNumber + "-" + config.propertyId;
+   if (!enabledByDefault) json["enabled_by_default"] = false;
    json["device"]["identifiers"][0] = spa.spaSerialNumber;
    json["device"]["serial_number"] = spa.spaSerialNumber;
    json["device"]["name"] = spa.spaName;
@@ -43,9 +45,9 @@ void generateCommonAdJSON(
 
 }
 
-void generateSensorAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, String stateClass, String unitOfMeasure) {
+void generateSensorAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, String stateClass, String unitOfMeasure, bool enabledByDefault) {
    JsonDocument json;
-   generateCommonAdJSON(json, config, spa, discoveryTopic, "sensor");
+   generateCommonAdJSON(json, config, spa, discoveryTopic, "sensor", enabledByDefault);
 
    if (!unitOfMeasure.isEmpty()) json["unit_of_measurement"] = unitOfMeasure;
    if (!stateClass.isEmpty()) json["state_class"] = stateClass;
@@ -53,16 +55,16 @@ void generateSensorAdJSON(String& output, const AutoDiscoveryInformationTemplate
    serializeJson(json, output);
 }
 
-void generateBinarySensorAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic) {
+void generateBinarySensorAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, bool enabledByDefault) {
    JsonDocument json;
-   generateCommonAdJSON(json, config, spa, discoveryTopic, "binary_sensor");
+   generateCommonAdJSON(json, config, spa, discoveryTopic, "binary_sensor", enabledByDefault);
 
    serializeJson(json, output);
 }
 
-void generateTextAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, String regex) {
+void generateTextAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, String regex, bool enabledByDefault) {
    JsonDocument json;
-   generateCommonAdJSON(json, config, spa, discoveryTopic, "text");
+   generateCommonAdJSON(json, config, spa, discoveryTopic, "text", enabledByDefault);
 
    json["command_topic"] = spa.commandTopic + "/" + config.propertyId;
    if (!regex.isEmpty()) json["pattern"] = regex;
@@ -70,18 +72,18 @@ void generateTextAdJSON(String& output, const AutoDiscoveryInformationTemplate& 
    serializeJson(json, output);
 }
 
-void generateSwitchAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic) {
+void generateSwitchAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, bool enabledByDefault) {
    JsonDocument json;
-   generateCommonAdJSON(json, config, spa, discoveryTopic, "switch");
+   generateCommonAdJSON(json, config, spa, discoveryTopic, "switch", enabledByDefault);
 
    json["command_topic"] = spa.commandTopic + "/" + config.propertyId;
 
    serializeJson(json, output);
 }
 
-void generateFanAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, int min, int max, const String* modes, const size_t modesSize) {
+void generateFanAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, int min, int max, const String* modes, const size_t modesSize, bool enabledByDefault) {
    JsonDocument json;
-   generateCommonAdJSON(json, config, spa, discoveryTopic, "fan");
+   generateCommonAdJSON(json, config, spa, discoveryTopic, "fan", enabledByDefault);
 
    // Find the last character that is not a space or curly brace
    int lastIndex = config.valueTemplate.length() - 1;
@@ -117,9 +119,9 @@ void generateFanAdJSON(String& output, const AutoDiscoveryInformationTemplate& c
    serializeJson(json, output);
 }
 
-void generateClimateAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic) {
+void generateClimateAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, bool enabledByDefault) {
    JsonDocument json;
-   generateCommonAdJSON(json, config, spa, discoveryTopic, "climate");
+   generateCommonAdJSON(json, config, spa, discoveryTopic, "climate", enabledByDefault);
 
    // Find the last character that is not a space or curly brace
    int lastIndex = config.valueTemplate.length() - 1;

--- a/lib/HAAutoDiscovery/HAAutoDiscovery.h
+++ b/lib/HAAutoDiscovery/HAAutoDiscovery.h
@@ -33,17 +33,17 @@ struct AutoDiscoveryInformationTemplate {
 /// @param spa Structure to define Spa information
 /// @param discoveryTopic String to retun discovrery topic
 /// @param type String to provide the type
-void generateCommonAdJSON(JsonDocument& json, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, String type);
+void generateCommonAdJSON(JsonDocument& json, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, String type, bool enabledByDefault=true);
 
-void generateSensorAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, String stateClass="", String unitOfMeasure="");
-void generateBinarySensorAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic);
-void generateTextAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, String regex="");
-void generateSwitchAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic);
+void generateSensorAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, String stateClass="", String unitOfMeasure="", bool enabledByDefault=true);
+void generateBinarySensorAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, bool enabledByDefault=true);
+void generateTextAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, String regex="", bool enabledByDefault=true);
+void generateSwitchAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, bool enabledByDefault=true);
 
 template <typename T, size_t N>
-void generateSelectAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, const std::array<T, N>& options) {
+void generateSelectAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, const std::array<T, N>& options, bool enabledByDefault=true) {
    JsonDocument json;
-   generateCommonAdJSON(json, config, spa, discoveryTopic, "select");
+   generateCommonAdJSON(json, config, spa, discoveryTopic, "select", enabledByDefault);
 
    json["command_topic"] = spa.commandTopic + "/" + config.propertyId;
    JsonArray opts = json["options"].to<JsonArray>();
@@ -52,12 +52,12 @@ void generateSelectAdJSON(String& output, const AutoDiscoveryInformationTemplate
    serializeJson(json, output);
 }
 
-void generateFanAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, int min, int max, const String* modes, const size_t modesSize=0);
+void generateFanAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, int min, int max, const String* modes, const size_t modesSize=0, bool enabledByDefault=true);
 
 template <typename T, size_t N>
-void generateLightAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, const std::array<T, N>& colorModes) {
+void generateLightAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, const std::array<T, N>& colorModes, bool enabledByDefault=true) {
    JsonDocument json;
-   generateCommonAdJSON(json, config, spa, discoveryTopic, "light");
+   generateCommonAdJSON(json, config, spa, discoveryTopic, "light", enabledByDefault);
 
    json["brightness_state_topic"] = spa.stateTopic;
    json["color_mode_state_topic"] = spa.stateTopic;
@@ -94,7 +94,7 @@ void generateLightAdJSON(String& output, const AutoDiscoveryInformationTemplate&
    serializeJson(json, output);
 }
 
-void generateClimateAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic);
+void generateClimateAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, bool enabledByDefault=true);
 
 /*
 struct SensorAdConfig {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -352,13 +352,12 @@ void mqttHaAutoDiscovery() {
   generateSelectAdJSON(output, ADConf, spa, discoveryTopic, si.sleepSelection);
   mqttClient.publish(discoveryTopic.c_str(), output.c_str(), true);
 
-  /*
   ADConf.displayName = "Date Time";
   ADConf.valueTemplate = "{{ value_json.status.datetime }}";
   ADConf.propertyId = "status_datetime";
   ADConf.deviceClass = "";
   ADConf.entityCategory = "config";
-  generateTextAdJSON(output, ADConf, spa, discoveryTopic, "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}");
+  generateTextAdJSON(output, ADConf, spa, discoveryTopic, "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}", false);
   mqttClient.publish(discoveryTopic.c_str(), output.c_str(), true);
 
   ADConf.displayName = "Day of Week";
@@ -366,9 +365,8 @@ void mqttHaAutoDiscovery() {
   ADConf.propertyId = "status_dayOfWeek";
   ADConf.deviceClass = "";
   ADConf.entityCategory = "config";
-  generateSelectAdJSON(output, ADConf, spa, discoveryTopic, si.spaDayOfWeekStrings);
+  generateSelectAdJSON(output, ADConf, spa, discoveryTopic, si.spaDayOfWeekStrings, false);
   mqttClient.publish(discoveryTopic.c_str(), output.c_str(), true);
-  */
   
   ADConf.displayName = "Sleep Timer 1 Begin";
   ADConf.valueTemplate = "{{ value_json.sleepTimers.timer1.begin }}";


### PR DESCRIPTION
Re-introduced date/time and day of week as disabled entities, so users can manually enable them if they desire.

Note: if the entities still exist in HA, they will stay enabled, the user can disable them if that is the desired outcome.

I have an automation that uses the date/time from the spa, and updates the time if it drifts too far... Also helpful for day light saving adjustments. I use this in my configuration.yaml to stop the HA logs from being spammed:

```
recorder:
  exclude:
    entities:
      - text.espa_date_time

logbook:
  exclude:
    entities:
      - text.espa_date_time
```