### PR TITLE
support for ESP32-C3 supermini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = esp32dev, espa-v1, espa-v2
+default_envs = esp32dev, espa-v1, espa-v2, esp32-c3-devkitm-1
 ; data_dir = {$PROJECT_DIR}/data
 
 [env:spa-base]
@@ -87,3 +87,19 @@ build_flags =
   -D EN_PIN=9           ; Enable/config button
   -D GP_PIN=21          ; General purpose button (reserved)
   -D SPA_SERIAL=Serial1 ; ESP32-C6 only has UART0/UART1, no UART2
+
+[env:esp32-c3-devkitm-1]
+extends = env:spa-base
+# ESP32-C3 DevKitC-1 for esp32-c3 super mini
+# super mini only has one serial rx/tx, so serial debugging is disabled.
+framework = arduino 
+board = esp32-c3-devkitm-1
+board_build.mcu = esp32c3
+board_build.partitions = partitions/espa_v2_partitions.csv
+board_upload.flash_size = 4MB
+build_flags =
+  -D ESP32_C3=1
+  -D RX_PIN=20
+  -D TX_PIN=21
+  -D EN_PIN=0
+  -D SPA_SERIAL=Serial0 ; ESP32-C3 only has UART0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -646,8 +646,10 @@ void setup() {
     pinMode(GP_PIN, INPUT_PULLUP);
   #endif
 
-  Serial.begin(115200);
-  
+  #if !defined(ESP32_C3)
+    Serial.begin(115200);
+  #endif
+
   #if defined(ESPA_V2)
     // ESP32-C6: Wait for USB CDC to connect (with timeout)
     unsigned long startWait = millis();
@@ -657,8 +659,12 @@ void setup() {
     delay(100);  // Extra settling time for USB
   #endif
   
-  Serial.setDebugOutput(true);
-  Debug.setSerialEnabled(true);
+  #if defined(ESP32_C3) // ESP32-C3 can not support serial output since it only has 1 uart
+    Debug.setSerialEnabled(false);
+  #else
+    Serial.setDebugOutput(true);
+    Debug.setSerialEnabled(true);
+  #endif
 
   si.begin();  // Initialize SpaInterface serial communication
 


### PR DESCRIPTION
This PR has the modifications necessary to run ESPySpa on the ESP32-c3 SuperMini, a very minimal and small esp32 implementation, allowing for a very low cost SpaNet integration (under $5 for a voltage buck, resistors and the supermini & antenna).  A Supermini with external (ipex) antenna is almost certainly required. 

The SuperMini typically has 4MB of flash and only one UART on pins 20 and 21, so serial logging output must be disabled.  

Submitting this PR as a reference for others wanting to experiement the ESP32-C3 SuperMini, so the PR could be a branch of it's own and doesn't need to be merged to master branch.  This probably isn't worth the effort for most folks, so I encourage them buy a supported ESpySpa device from https://store.espa.diy/