### PR TITLE
Disable WiFi modem-sleep to fix MQTT keepalive disconnects

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -691,6 +691,10 @@ void setup() {
 
   //WiFi.begin(config.WiFiSSID.getValue().c_str(), config.WiFiPassword.getValue().c_str());
   WiFi.begin();
+  // Disable WiFi modem-sleep. With the default power-save mode the radio sleeps
+  // between DTIM beacons, which delays the loop()/MQTT keepalive and causes the
+  // broker to drop the client ("exceeded timeout") on networks with any latency.
+  WiFi.setSleep(false);
   if (WiFi.waitForConnectResult() == WL_CONNECTED) {
     debugI("Connected to Wi-Fi as %s", WiFi.getHostname());
     int totalTry = 5;


### PR DESCRIPTION
## Problem

On a strong, stable WiFi link the bridge repeatedly disconnects from the MQTT broker with `exceeded timeout`, sometimes staying offline for hours, leaving gaps in Home Assistant history.

## Root cause

The ESP32 defaults to WiFi modem-sleep (power-save). The radio sleeps between DTIM beacons, delaying `loop()` and therefore the PubSubClient keepalive (`MQTT_KEEPALIVE`, default 15 s). When the `PINGREQ` is delayed past 1.5× the interval, the broker drops the client.

Evidence from an affected espa-v1 / ESP32 bridge:
- UniFi reported **-57 dBm**, **100% AP satisfaction**, but `powersave_enabled=true`
- Dropped every few minutes; multi-hour gaps in history
- A second client on the same AP with power-save **off** never dropped
- `ping` showed 0% loss but ~100 ms latency aligned to beacon intervals (classic modem-sleep)

## Fix

Call `WiFi.setSleep(false)` after `WiFi.begin()` so the radio stays awake and keepalives are delivered on time. One line (+ comment); negligible extra power draw on a mains-powered spa bridge.
